### PR TITLE
Notices when starting workbreeze daemon

### DIFF
--- a/www/applications/workbreeze.php
+++ b/www/applications/workbreeze.php
@@ -67,7 +67,7 @@ class Workbreeze extends AppInstance {
 		Daemon::log('Workbreeze up');
 	}
 
-	public function onShutdown() {
+	public function onShutdown($graceful = false) {
 		return true;
 	}
 


### PR DESCRIPTION
When starting Workbreeze PHPD a notice raises. Running _phpDaemon 0.9.0_

```
[PHPD] Notice (userland): Declaration of Workbreeze::onShutdown() should be compatible with AppInstance::onShutdown($graceful = false) in /home/dimon3000/Документы/Работа/Учёба/dromanov-workbreeze/sources/www/applications/workbreeze.php:94
#0  Debug::backtrace() called at [/opt/phpdaemon/lib/Daemon.php:167]
#1  Daemon::errorHandler() called at [/opt/phpdaemon/bin/phpd:53]
#2  {closure}() called at [/opt/phpdaemon/bin/phpd:53]
#3  {closure}()
#4  spl_autoload_call()
#5  class_exists() called at [/opt/phpdaemon/lib/AppResolver.php:99]
#6  AppResolver->appInstantiate() called at [/opt/phpdaemon/lib/AppResolver.php:43]
#7  AppResolver->preload() called at [/opt/phpdaemon/lib/Daemon_WorkerThread.php:82]
#8  Daemon_WorkerThread->run() called at [/opt/phpdaemon/bin/phpd:69]
```
